### PR TITLE
Add rich progress bars to Fangraphs fetch loop

### DIFF
--- a/fangraphs_api_extractor/handlers/player_fetch_handler.py
+++ b/fangraphs_api_extractor/handlers/player_fetch_handler.py
@@ -5,7 +5,19 @@ This module contains the handler logic for fetching player data
 from the Fangraphs Baseball API and parsing it into PlayerModel objects.
 """
 
+import time
 from typing import Dict, List, Tuple
+
+from rich.console import Group
+from rich.live import Live
+from rich.progress import (
+    BarColumn,
+    MofNCompleteColumn,
+    Progress,
+    TextColumn,
+    TimeElapsedColumn,
+    TimeRemainingColumn,
+)
 
 from fangraphs_api_extractor.managers import PlayersManager
 from fangraphs_api_extractor.models import PlayerModel
@@ -45,7 +57,7 @@ class PlayerFetchHandler:
             List of hitter PlayerModel objects
         """
         year = self.core_fangraphs.year
-        self.log.info(
+        self.log.debug(
             f"Fetching hitter projections for {year} from {projection_source}..."
         )
         try:
@@ -57,7 +69,7 @@ class PlayerFetchHandler:
                 hitters = hitters_manager.parse_players(
                     hitter_data, projection_source=projection_source
                 )
-                self.log.info(f"Parsed {len(hitters)} hitters from {projection_source}")
+                self.log.debug(f"Parsed {len(hitters)} hitters from {projection_source}")
                 return hitters
             else:
                 self.log.warning(
@@ -86,7 +98,7 @@ class PlayerFetchHandler:
         api_source = _batx_map.get(projection_source.lower(), projection_source)
 
         year = self.core_fangraphs.year
-        self.log.info(f"Fetching pitcher projections for {year} from {api_source}...")
+        self.log.debug(f"Fetching pitcher projections for {year} from {api_source}...")
         try:
             pitcher_data = self.core_fangraphs.get_projections_data(
                 "pit", projections_system=api_source
@@ -96,7 +108,7 @@ class PlayerFetchHandler:
                 pitchers = pitchers_manager.parse_players(
                     pitcher_data, projection_source=projection_source
                 )
-                self.log.info(
+                self.log.debug(
                     f"Parsed {len(pitchers)} pitchers from {projection_source}"
                 )
                 return pitchers
@@ -125,19 +137,74 @@ class PlayerFetchHandler:
         batters_by_source: Dict[str, List[PlayerModel]] = {}
         pitchers_by_source: Dict[str, List[PlayerModel]] = {}
 
+        batter_sources = sources.get("batters", [])
+        pitcher_sources = sources.get("pitchers", [])
         for key in sources:
-            match key:
-                case "batters":
-                    for source in sources["batters"]:
-                        self.log.info(f"Fetching batters data from source: {source}")
+            if key not in ("batters", "pitchers"):
+                self.log.warning(f"Invalid source structure: {key}")
+
+        total_fetches = len(batter_sources) + len(pitcher_sources)
+        fetch_start = time.perf_counter()
+
+        progress_columns = (
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            MofNCompleteColumn(),
+            TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+            TimeElapsedColumn(),
+            TimeRemainingColumn(),
+        )
+        # Inner progress hosts the ephemeral "Fetching: <source>" label that
+        # gets swapped per source — transient so it vanishes on exit. Outer
+        # progress hosts the persistent Batters / Pitchers / Total bars so
+        # their final elapsed times remain in scrollback after the run.
+        inner_progress = Progress(*progress_columns, transient=True)
+        outer_progress = Progress(*progress_columns, transient=False)
+
+        with Live(
+            Group(inner_progress, outer_progress), refresh_per_second=10
+        ):
+            overall_task = outer_progress.add_task(
+                "Total progress", total=total_fetches
+            )
+
+            if batter_sources:
+                batters_task = outer_progress.add_task(
+                    "Batters", total=len(batter_sources)
+                )
+                for source in batter_sources:
+                    label_task = inner_progress.add_task(
+                        f"Fetching: {source}", total=1
+                    )
+                    try:
                         hitters = self.fetch_hitters(projection_source=source)
                         batters_by_source[source] = hitters
-                case "pitchers":
-                    for source in sources["pitchers"]:
-                        self.log.info(f"Fetching pitchers data from source: {source}")
+                        inner_progress.advance(label_task)
+                        outer_progress.advance(batters_task)
+                        outer_progress.advance(overall_task)
+                    finally:
+                        inner_progress.remove_task(label_task)
+
+            if pitcher_sources:
+                pitchers_task = outer_progress.add_task(
+                    "Pitchers", total=len(pitcher_sources)
+                )
+                for source in pitcher_sources:
+                    label_task = inner_progress.add_task(
+                        f"Fetching: {source}", total=1
+                    )
+                    try:
                         pitchers = self.fetch_pitchers(projection_source=source)
                         pitchers_by_source[source] = pitchers
-                case _:
-                    self.log.warning(f"Invalid source structure: {key}")
+                        inner_progress.advance(label_task)
+                        outer_progress.advance(pitchers_task)
+                        outer_progress.advance(overall_task)
+                    finally:
+                        inner_progress.remove_task(label_task)
+
+        fetch_elapsed = time.perf_counter() - fetch_start
+        self.log.info(
+            f"Fetched {total_fetches} Fangraphs sources in {fetch_elapsed:.1f}s"
+        )
 
         return batters_by_source, pitchers_by_source

--- a/fangraphs_api_extractor/requests/core_fangraphs.py
+++ b/fangraphs_api_extractor/requests/core_fangraphs.py
@@ -171,7 +171,7 @@ class CoreFangraphs:
         merged_params.update(params or {})
 
         try:
-            self.logger.logging.info(
+            self.logger.logging.debug(
                 f"Fetching {position_group} projections with {projections_system}"
             )
             raw_data = self._get(params=merged_params)

--- a/fangraphs_api_extractor/utils/utils.py
+++ b/fangraphs_api_extractor/utils/utils.py
@@ -4,6 +4,14 @@ from datetime import datetime
 from decimal import ROUND_HALF_UP, Decimal
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+from rich.progress import (
+    BarColumn,
+    MofNCompleteColumn,
+    Progress,
+    TextColumn,
+    TimeElapsedColumn,
+)
+
 from fangraphs_api_extractor.utils import Logger
 from fangraphs_api_extractor.utils.string_utils import normalize_string
 
@@ -59,48 +67,55 @@ def serialize_players(players: List["PlayerModel"]) -> List[Dict]:
             return {}
         return model.model_dump(by_alias=True, exclude_none=True)
 
-    for i, player in enumerate(players):
-        try:
-            # Ensure we have the basic player fields
-            serialized_player: Dict[str, Any] = {
-                "name": getattr(player, "name", "unknown"),
-                "ascii_name": getattr(
-                    player,
-                    "ascii_name",
-                    normalize_string(getattr(player, "name", "unknown")),
-                ),
-                "team": getattr(player, "team", "FA"),
-                "playerid": getattr(player, "playerid", "unknown"),
-                "xmlbam_id": getattr(player, "xmlbam_id", -1),
-                "slug": getattr(player, "slug", ""),
-                "stats_api": getattr(player, "stats_api", ""),
-                "projections": {},
-                "projs_updated": {},
-                "ros": {},
-            }
+    with Progress(
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        MofNCompleteColumn(),
+        TimeElapsedColumn(),
+        transient=True,
+    ) as progress:
+        task = progress.add_task("Serializing players", total=len(players))
+        for i, player in enumerate(players):
+            try:
+                # Ensure we have the basic player fields
+                serialized_player: Dict[str, Any] = {
+                    "name": getattr(player, "name", "unknown"),
+                    "ascii_name": getattr(
+                        player,
+                        "ascii_name",
+                        normalize_string(getattr(player, "name", "unknown")),
+                    ),
+                    "team": getattr(player, "team", "FA"),
+                    "playerid": getattr(player, "playerid", "unknown"),
+                    "xmlbam_id": getattr(player, "xmlbam_id", -1),
+                    "slug": getattr(player, "slug", ""),
+                    "stats_api": getattr(player, "stats_api", ""),
+                    "projections": {},
+                    "projs_updated": {},
+                    "ros": {},
+                }
 
-            for slot in ("projections", "projs_updated", "ros"):
-                try:
-                    serialized_player[slot] = _dump(getattr(player, slot, None))
-                except Exception as e:
-                    log.error(f"Error processing {slot} for player {i + 1}: {e}")
+                for slot in ("projections", "projs_updated", "ros"):
+                    try:
+                        serialized_player[slot] = _dump(getattr(player, slot, None))
+                    except Exception as e:
+                        log.error(f"Error processing {slot} for player {i + 1}: {e}")
 
-            # Round all float values in the player record to 3 decimal places
-            serialized_player = round_floats(serialized_player)
+                # Round all float values in the player record to 3 decimal places
+                serialized_player = round_floats(serialized_player)
 
-            player_data_list.append(serialized_player)
+                player_data_list.append(serialized_player)
 
-            if i % 100 == 0:  # Log progress every 100 players
-                log.info(f"Serialized {i + 1}/{len(players)} players")
+            except Exception as e:
+                log.error(f"Error serializing player {i + 1}: {e}")
 
-        except Exception as e:
-            log.error(f"Error serializing player {i + 1}: {e}")
-
-            # Still add basic info even if there's an error
-            name = getattr(player, "name", "unknown")
-            player_data_list.append(
-                {"name": name, "ascii_name": normalize_string(name), "error": str(e)}
-            )
+                # Still add basic info even if there's an error
+                name = getattr(player, "name", "unknown")
+                player_data_list.append(
+                    {"name": name, "ascii_name": normalize_string(name), "error": str(e)}
+                )
+            finally:
+                progress.update(task, advance=1)
 
     log.info(f"Completed serialization with {len(player_data_list)} results")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.13"
 dependencies = [
     "requests>=2.32.3,<3.0.0",
     "pydantic>=2.11.4,<3.0.0",
-    "tqdm>=4.67.1,<5.0.0"
+    "rich>=13.0.0,<15.0.0"
 ]
 
 [project.optional-dependencies]

--- a/tests/handlers/test_player_fetch_handler.py
+++ b/tests/handlers/test_player_fetch_handler.py
@@ -259,3 +259,23 @@ def test_fetch_all_players_multi_source_empty_sources(mock_core_fangraphs):
     assert pitchers_by_source == {}
     # API should not be called
     mock_core_fangraphs.get_projections_data.assert_not_called()
+
+
+def test_fetch_all_players_multi_source_invalid_key_warns(
+    mock_core_fangraphs, hitter_fixture_data
+):
+    """Unknown keys in the sources dict are warned about and otherwise ignored."""
+    mock_core_fangraphs.get_projections_data.return_value = hitter_fixture_data
+
+    handler = PlayerFetchHandler(mock_core_fangraphs)
+    handler.log = MagicMock()
+
+    sources = {"batters": ["steamer"], "garbage": ["steamer"]}
+    batters_by_source, pitchers_by_source = handler.fetch_all_players_multi_source(
+        sources
+    )
+
+    # Unknown key produces a warning, valid keys still process.
+    handler.log.warning.assert_any_call("Invalid source structure: garbage")
+    assert "steamer" in batters_by_source
+    assert pitchers_by_source == {}

--- a/uv.lock
+++ b/uv.lock
@@ -147,7 +147,7 @@ source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
     { name = "requests" },
-    { name = "tqdm" },
+    { name = "rich" },
 ]
 
 [package.optional-dependencies]
@@ -166,7 +166,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.5" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.1.1" },
     { name = "requests", specifier = ">=2.32.3,<3.0.0" },
-    { name = "tqdm", specifier = ">=4.67.1,<5.0.0" },
+    { name = "rich", specifier = ">=13.0.0,<15.0.0" },
 ]
 provides-extras = ["dev"]
 
@@ -227,6 +227,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d6/49/3732b0e8424ae35ad5c3166d9dd5bcdae43ce98775e0867a716ff5868064/librt-0.7.4-cp314-cp314t-win32.whl", hash = "sha256:8a461f6456981d8c8e971ff5a55f2e34f4e60871e665d2f5fde23ee74dea4eeb", size = 40276, upload-time = "2025-12-15T16:52:27.54Z" },
     { url = "https://files.pythonhosted.org/packages/35/d6/d8823e01bd069934525fddb343189c008b39828a429b473fb20d67d5cd36/librt-0.7.4-cp314-cp314t-win_amd64.whl", hash = "sha256:721a7b125a817d60bf4924e1eec2a7867bfcf64cfc333045de1df7a0629e4481", size = 46772, upload-time = "2025-12-15T16:52:28.653Z" },
     { url = "https://files.pythonhosted.org/packages/36/e9/a0aa60f5322814dd084a89614e9e31139702e342f8459ad8af1984a18168/librt-0.7.4-cp314-cp314t-win_arm64.whl", hash = "sha256:76b2ba71265c0102d11458879b4d53ccd0b32b0164d14deb8d2b598a018e502f", size = 39724, upload-time = "2025-12-15T16:52:29.836Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -428,15 +449,16 @@ wheels = [
 ]
 
 [[package]]
-name = "tqdm"
-version = "4.67.1"
+name = "rich"
+version = "14.3.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "markdown-it-py" },
+    { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/67/cae617f1351490c25a4b8ac3b8b63a4dda609295d8222bad12242dfdc629/rich-14.3.4.tar.gz", hash = "sha256:817e02727f2b25b40ef56f5aa2217f400c8489f79ca8f46ea2b70dd5e14558a9", size = 230524, upload-time = "2026-04-11T02:57:45.419Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/76/6d163cfac87b632216f71879e6b2cf17163f773ff59c00b5ff4900a80fa3/rich-14.3.4-py3-none-any.whl", hash = "sha256:07e7adb4690f68864777b1450859253bed81a99a31ac321ac1817b2313558952", size = 310480, upload-time = "2026-04-11T02:57:47.484Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Replace tqdm with rich for fetch + serialize loops.
- Live + Group pattern matches the Savant / ESPN style: inner ephemeral `Fetching: <source>` label swaps per source; outer Batters / Pitchers / Total bars persist after the live region exits so elapsed times stay in scrollback.
- Silence per-source `log.info` chatter in `core_fangraphs.get_projections_data` and `PlayerFetchHandler` (downgrade to `debug`). Those writes bypass rich's stdout redirect because `Logger`'s `StreamHandler` captured `sys.stdout` at construction time — they were tearing the live region into N stacked "Total progress" lines.
- `serialize_players` switched from the `% 100` log cadence to a `rich.Progress` block (transient=True — local CPU work, no need to persist).
- pyproject.toml: drop unused `tqdm>=4.67.1` dep, add `rich>=13.0.0,<15.0.0`.

## Test plan
- [x] `uv sync --extra dev` resolves cleanly with the new dep
- [x] `uv run python -m fangraphs_api_extractor --year 2026 --output-dir ./data` renders three persisted blocks of bars (one per slot: projections, projs_updated, ros), each showing final Batters / Pitchers / Total elapsed times
- [x] No "Total progress" stacking — bars render in-place during fetch
- [x] `uv run pytest tests/ -q` still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)