### PR TITLE
feat: solve Fangraphs Cloudflare challenge via FlareSolverr

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,12 @@ save_extraction_results          # writes fangraph_{batters,pitchers}_<year>_<ts
 `__main__.py` CLI is a thin wrapper that builds `sources` / `weights` dicts and
 calls `PlayerRunner.run()`.
 
+**Cloudflare:** Fangraphs fronts `/api/projections` with a managed JS challenge.
+`CoreFangraphs` solves it via a FlareSolverr sidecar when `FLARESOLVERR_URL` is
+set (adopts the `cf_clearance` cookie + the solver's User-Agent on the session).
+Without it, pulls 403 while the challenge is active. Full story and the
+dead-ends tried: [`docs/the-wall-goes-up.md`](docs/the-wall-goes-up.md).
+
 ## Three-slot projection schema
 
 Each player carries **three independent projection blobs**, each merged from a

--- a/docs/the-wall-goes-up.md
+++ b/docs/the-wall-goes-up.md
@@ -1,0 +1,137 @@
+# The Wall Goes Up: Surviving Fangraphs' Cloudflare Challenge
+
+*The day the `updates` and `ros` pulls started returning 403, and what it took
+to get them back. A record of every dead-end we tried before the one that
+worked — so nobody re-walks the same blocked paths.*
+
+---
+
+## What broke
+
+In-season, the `projs_updated` and `ros` slots began failing with HTTP **403**.
+The pre-season `projections` slot looked fine — but only because its data had
+been scraped back in spring, before the wall went up. The "updated/ros only"
+pattern was a *timeline artifact*, not an endpoint-specific block: those two
+slots only publish mid-season, so they were simply the first pulls to hit the
+new defense.
+
+The 403 body told the real story:
+
+```
+cf-mitigated: challenge
+server: cloudflare
+...
+Just a moment...
+Performing security verification
+Ray ID: ...
+```
+
+Fangraphs had put the entire `fangraphs.com` zone behind a **Cloudflare managed
+JS challenge** (`_cf_chl_opt`, `/cdn-cgi/challenge-platform/...`). Every request
+to `/api/projections` — and even the homepage — now gets an interstitial that
+must execute challenge JavaScript and return a `cf_clearance` cookie. Unprotected
+paths like `/robots.txt` stayed `200`, which is how we confirmed it was a
+path-scoped challenge and not an IP ban.
+
+## The dead-ends (all 403)
+
+Every header/fingerprint trick fails against a managed JS challenge, because the
+challenge is not checking *what you claim to be* — it's checking *whether you can
+run its JavaScript in a real browser environment*. For the record, what we tried
+and what we got:
+
+| Approach | Result | Why it failed |
+|---|---|---|
+| `requests` + browser User-Agent | 403 | No JS engine; UA is irrelevant to a managed challenge |
+| `requests` + `Referer`/`Accept`/`Accept-Language` | 403 | Same — headers don't execute the challenge |
+| `curl_cffi` `impersonate="chrome"` (TLS/JA3 match) | 403 | Beats *passive* fingerprinting, not an *active* JS challenge |
+| `cloudscraper` (legacy IUAM solver) | 403 | Solves the older JS challenge, not the modern managed/Turnstile one |
+| Playwright **headless** (bundled Chromium) | stuck on "Just a moment" | Automation + open-source Chromium build detected |
+| `patchright` (stealth) headless | stuck | Same environment signals |
+| `patchright` **headful** | stuck | — |
+| `patchright` real **Chrome** channel, headful | stuck | — |
+
+The headful failures were initially alarming — a real browser *should* pass. Two
+explanations were confounded and could not be separated from the test machine:
+(a) Cloudflare detecting the CDP/automation channel even under stealth, or (b)
+the test IP getting penalty-boxed after ~40 failed solves. The clean tie-breaker:
+opening `https://www.fangraphs.com/projections` in a **normal human Chrome on the
+same machine/IP** loaded instantly. Same IP, real browser passes, automated
+browser doesn't → the wall is **automation detection**, not IP reputation.
+
+That ruled out "bake Playwright into the image and drive it ourselves" — our best
+stealth attempt with a real Chrome binary still couldn't pass.
+
+## What worked: FlareSolverr as a sidecar
+
+[FlareSolverr](https://github.com/FlareSolverr/FlareSolverr) runs a stealth-patched
+browser purpose-built to clear Cloudflare challenges. You POST it a URL; it drives
+its browser through the challenge and hands back the `cf_clearance` cookie plus the
+exact User-Agent it used. We then replay those against the API with plain
+`requests`:
+
+```
+POST flaresolverr:8191/v1  {cmd: request.get, url: .../projections}
+  -> status: ok, "Challenge solved!"
+  -> solution.cookies[cf_clearance], solution.userAgent
+
+requests.get(/api/projections?type=steamerr, cookie+UA)  -> 200
+```
+
+Verified end-to-end through the real extractor:
+
+```
+Obtained Cloudflare clearance via FlareSolverr
+Slot 'projections':   4186 hitters, 5367 pitchers
+Slot 'projs_updated': 4377 hitters, 5588 pitchers   (was 403)
+Slot 'ros':            630 hitters, 3361 pitchers    (was 403)
+```
+
+## The load-bearing constraint: cf_clearance is bound to UA + egress IP
+
+Cloudflare ties the `cf_clearance` cookie to the **exact User-Agent** and the
+**egress IP** that solved the challenge. The cookie is only honored when both
+match on replay. Two consequences shape the design:
+
+1. **Adopt FlareSolverr's User-Agent.** The solver runs a Linux Chrome; we
+   override the static `USER_AGENT_HEADER` with whatever UA it reports. Sending
+   the old hardcoded UA with its cookie → instant 403.
+2. **Co-locate solver and consumer.** The solver and the extractor must share an
+   egress IP. In the Prefect compose stack both the `flaresolverr` container and
+   the `runner` container NAT out through the host's public IP → same egress →
+   cookie valid. A solver-as-a-service in a different datacenter would mint a
+   cookie keyed to the *wrong* IP and every replay would 403. This is why we run
+   FlareSolverr as a **local sidecar**, not a remote dependency.
+
+## How it's wired
+
+- **`utils/constants.py`** — `FANGRAPHS_CHALLENGE_URL` (the HTML page solved
+  against; clearance is zone-wide so it authorizes the same-zone API).
+- **`requests/core_fangraphs.py`** — reads `FLARESOLVERR_URL` from the
+  environment. On the first `_get`, `_ensure_clearance()` solves once and caches
+  the cookie + UA on the session. A mid-run 403 triggers exactly one re-solve and
+  retry (the cookie has a TTL). When `FLARESOLVERR_URL` is unset the extractor
+  behaves as before — useful for environments where the challenge isn't active.
+- **`MTBL_Prefect/docker-compose.yml`** — adds the `flaresolverr` service and
+  sets `FLARESOLVERR_URL=http://flaresolverr:8191/v1` on the runner. Published on
+  `127.0.0.1:8191` for host-direct flows; loopback-bound because the solver
+  proxies arbitrary URLs through a real browser and must never face the LAN.
+
+### A bug fixed along the way
+
+The pre-existing `_get` called module-level `requests.get()` and only forwarded
+cookies — it never used `self.session`, so the session's User-Agent (and any
+future `cf_clearance`) was silently dropped between calls. That made cookie reuse
+impossible. `_get` now goes through `self.session.get()`, which both fixes the
+latent bug and is what makes the clearance cookie stick.
+
+## If the wall changes again
+
+FlareSolverr tracks Cloudflare's evolving challenges but is not guaranteed to
+clear every future variant. If `status: ok` stops coming back: update the
+FlareSolverr image first. If that fails, the fallbacks in rough order of effort
+are a residential-proxy egress, a logged-in Fangraphs member session (the site
+runs WordPress with member auth — untested as a challenge bypass), or an
+alternate projections source. Header/TLS-impersonation tricks are *not* on that
+list — this document is the evidence that they don't work against a managed JS
+challenge.

--- a/fangraphs_api_extractor/requests/core_fangraphs.py
+++ b/fangraphs_api_extractor/requests/core_fangraphs.py
@@ -12,7 +12,10 @@ from fangraphs_api_extractor.utils import (
     PROJECTION_SYSTEMS,
     Logger,
 )
-from fangraphs_api_extractor.utils.constants import USER_AGENT_HEADER
+from fangraphs_api_extractor.utils.constants import (
+    FANGRAPHS_CHALLENGE_URL,
+    USER_AGENT_HEADER,
+)
 from fangraphs_api_extractor.utils.errors import (
     InvalidPositionError,
     InvalidPositionGroupError,
@@ -24,6 +27,7 @@ class ResponseStatus(Enum):
     """Enum representing possible API response statuses"""
 
     SUCCESS = 200
+    FORBIDDEN = 403
     NOT_FOUND = 404
     RATE_LIMITED = 429
     SERVER_ERROR = 500
@@ -55,6 +59,17 @@ class CoreFangraphs:
         # Set the API URL
         self.fg_projections_url = FANGRAPHS_API_ENDPOINT
 
+        # Cloudflare clearance. Fangraphs fronts the projections API with a
+        # managed JS challenge that plain HTTP clients cannot pass. When
+        # FLARESOLVERR_URL is set we delegate solving to a FlareSolverr sidecar,
+        # then adopt the cf_clearance cookie + the exact User-Agent it used and
+        # reuse them for every API call (cf_clearance is bound to that UA and the
+        # egress IP). Unset → legacy behavior (requests go out unauthenticated
+        # and will 403 while the challenge is active).
+        self.flaresolverr_url = os.environ.get("FLARESOLVERR_URL")
+        self._clearance_lock = Lock()
+        self._clearance_ready = False
+
     def _check_request_status(
         self,
         status: int,
@@ -75,6 +90,12 @@ class CoreFangraphs:
                 case ResponseStatus.SUCCESS.value:
                     return
 
+                case ResponseStatus.FORBIDDEN.value:
+                    self.logger.logging.warning(
+                        "Forbidden (403) — Cloudflare challenge not satisfied. "
+                        "Set FLARESOLVERR_URL to enable challenge solving."
+                    )
+
                 case ResponseStatus.NOT_FOUND.value:
                     self.logger.logging.warning(f"Endpoint not found: {extend}")
 
@@ -89,6 +110,56 @@ class CoreFangraphs:
 
                 case _:
                     self.logger.logging.warning(f"Unknown error: {status}")
+
+    def _ensure_clearance(self) -> None:
+        """Lazily obtain a Cloudflare clearance cookie before the first request.
+
+        No-op when FLARESOLVERR_URL is unset or clearance is already held. The
+        lock makes the one-time solve safe if requests are ever parallelized.
+        """
+        if not self.flaresolverr_url or self._clearance_ready:
+            return
+        with self._clearance_lock:
+            if not self._clearance_ready:
+                self._solve_cloudflare()
+
+    def _solve_cloudflare(self) -> None:
+        """Solve Fangraphs' Cloudflare challenge via FlareSolverr and apply the
+        resulting cf_clearance cookie + User-Agent to the session.
+
+        Raises on transport or solve failure so the caller (and Prefect's
+        transient-retry) can react rather than silently 403-looping.
+        """
+        payload = {
+            "cmd": "request.get",
+            "url": FANGRAPHS_CHALLENGE_URL,
+            "maxTimeout": 60000,
+        }
+        resp = requests.post(self.flaresolverr_url, json=payload, timeout=90)
+        resp.raise_for_status()
+        data = resp.json()
+        if data.get("status") != "ok":
+            raise RuntimeError(
+                "FlareSolverr could not solve the Cloudflare challenge: "
+                f"{data.get('message')}"
+            )
+        solution = data["solution"]
+        # cf_clearance is keyed to the solving browser's User-Agent — adopt it
+        # verbatim, overriding the static USER_AGENT_HEADER set at construction.
+        self.session.headers["User-Agent"] = solution["userAgent"]
+        for cookie in solution.get("cookies", []):
+            # FlareSolverr normally returns a domain; fall back to the Fangraphs
+            # zone (the only host we solve) so cookie matching never sees None.
+            self.session.cookies.set(
+                cookie["name"],
+                cookie["value"],
+                domain=cookie.get("domain") or ".fangraphs.com",
+            )
+        self._clearance_ready = True
+        with self.logger_lock:
+            self.logger.logging.info(
+                "Obtained Cloudflare clearance via FlareSolverr"
+            )
 
     def _get(
         self,
@@ -107,19 +178,44 @@ class CoreFangraphs:
         Returns:
             The JSON response from the API
         """
+        self._ensure_clearance()
         endpoint = self.fg_projections_url + extend
-        r = requests.get(
-            endpoint, params=params, headers=headers, cookies=self.session.cookies
-        )
+        # Use the session (not module-level requests.get) so the cf_clearance
+        # cookie and solved User-Agent travel with every call.
+        r = self.session.get(endpoint, params=params, headers=headers)
+
+        # A 403 mid-run means the cf_clearance cookie expired or was rejected.
+        # Re-solve once and retry before surfacing the failure.
+        if r.status_code == ResponseStatus.FORBIDDEN.value and self.flaresolverr_url:
+            with self.logger_lock:
+                self.logger.logging.warning(
+                    "403 from Fangraphs — refreshing Cloudflare clearance"
+                )
+            with self._clearance_lock:
+                self._clearance_ready = False
+            self._ensure_clearance()
+            r = self.session.get(endpoint, params=params, headers=headers)
+
         self._check_request_status(r.status_code, extend)
 
+        # Only a 200 carries a JSON body. On any other status (e.g. an
+        # unresolved 403 serving the Cloudflare challenge HTML) raise a clear
+        # error rather than letting r.json() throw a cryptic JSONDecodeError —
+        # get_projections_data catches this and returns None.
+        if r.status_code != ResponseStatus.SUCCESS.value:
+            raise RuntimeError(
+                f"Fangraphs returned HTTP {r.status_code} for "
+                f"'{extend or 'projections'}'"
+            )
+
+        data = r.json()
         if self.logger:
             with self.logger_lock:
                 self.logger.log_request(
-                    endpoint=endpoint, params=params, headers=headers, response=r.json()
+                    endpoint=endpoint, params=params, headers=headers, response=data
                 )
 
-        return r.json()
+        return data
 
     def get_projections_data(
         self,

--- a/fangraphs_api_extractor/utils/constants.py
+++ b/fangraphs_api_extractor/utils/constants.py
@@ -2,6 +2,12 @@ from enum import Enum
 
 FANGRAPHS_API_ENDPOINT = "https://www.fangraphs.com/api/projections?"
 
+# Cloudflare-protected HTML page used to mint a cf_clearance cookie via
+# FlareSolverr. Fangraphs fronts the whole fangraphs.com zone with a managed JS
+# challenge; solving against this page yields a cf_clearance cookie that
+# authorizes the same-zone /api/projections calls.
+FANGRAPHS_CHALLENGE_URL = "https://www.fangraphs.com/projections"
+
 # deprecated
 BUILD_ID = "hkm1KP0YmmKjp8AmZS3FM"
 FANGRAPHS_CORE_BUILD_ENDPOINT = "https://www.fangraphs.com/_next/data/" + BUILD_ID

--- a/tests/requests/test_core_fangraphs.py
+++ b/tests/requests/test_core_fangraphs.py
@@ -67,7 +67,7 @@ def test_check_request_status_unknown(core_fangraphs):
     core_fangraphs._check_request_status(999, "/test")
 
 
-@patch("fangraphs_api_extractor.requests.core_fangraphs.requests.get")
+@patch("fangraphs_api_extractor.requests.core_fangraphs.requests.Session.get")
 def test_get_request_success(mock_get, core_fangraphs):
     """Test successful GET request."""
     # Mock response
@@ -82,7 +82,7 @@ def test_get_request_success(mock_get, core_fangraphs):
     mock_get.assert_called_once()
 
 
-@patch("fangraphs_api_extractor.requests.core_fangraphs.requests.get")
+@patch("fangraphs_api_extractor.requests.core_fangraphs.requests.Session.get")
 def test_get_request_with_headers(mock_get, core_fangraphs):
     """Test GET request with custom headers."""
     mock_response = Mock()
@@ -135,7 +135,7 @@ def test_get_projections_data_invalid_projections_system(core_fangraphs):
     assert result is None
 
 
-@patch("fangraphs_api_extractor.requests.core_fangraphs.requests.get")
+@patch("fangraphs_api_extractor.requests.core_fangraphs.requests.Session.get")
 def test_get_projections_data_success_bat(mock_get, core_fangraphs):
     """Test successful get_projections_data for batters."""
     mock_response = Mock()
@@ -151,7 +151,7 @@ def test_get_projections_data_success_bat(mock_get, core_fangraphs):
     mock_get.assert_called_once()
 
 
-@patch("fangraphs_api_extractor.requests.core_fangraphs.requests.get")
+@patch("fangraphs_api_extractor.requests.core_fangraphs.requests.Session.get")
 def test_get_projections_data_success_pit(mock_get, core_fangraphs):
     """Test successful get_projections_data for pitchers."""
     mock_response = Mock()
@@ -166,7 +166,7 @@ def test_get_projections_data_success_pit(mock_get, core_fangraphs):
     assert result == {"pitchers": [{"name": "Test Pitcher"}]}
 
 
-@patch("fangraphs_api_extractor.requests.core_fangraphs.requests.get")
+@patch("fangraphs_api_extractor.requests.core_fangraphs.requests.Session.get")
 def test_get_projections_data_with_custom_params(mock_get, core_fangraphs):
     """Test get_projections_data with custom parameters."""
     mock_response = Mock()
@@ -182,7 +182,7 @@ def test_get_projections_data_with_custom_params(mock_get, core_fangraphs):
     assert result == {"data": "test"}
 
 
-@patch("fangraphs_api_extractor.requests.core_fangraphs.requests.get")
+@patch("fangraphs_api_extractor.requests.core_fangraphs.requests.Session.get")
 def test_get_projections_data_exception(mock_get, core_fangraphs):
     """Test get_projections_data when request raises exception."""
     mock_get.side_effect = Exception("Network error")
@@ -197,6 +197,7 @@ def test_get_projections_data_exception(mock_get, core_fangraphs):
 def test_response_status_enum():
     """Test ResponseStatus enum values."""
     assert ResponseStatus.SUCCESS.value == 200
+    assert ResponseStatus.FORBIDDEN.value == 403
     assert ResponseStatus.NOT_FOUND.value == 404
     assert ResponseStatus.RATE_LIMITED.value == 429
     assert ResponseStatus.SERVER_ERROR.value == 500
@@ -204,7 +205,7 @@ def test_response_status_enum():
     assert ResponseStatus.UNKNOWN_ERROR.value == 0
 
 
-@patch("fangraphs_api_extractor.requests.core_fangraphs.requests.get")
+@patch("fangraphs_api_extractor.requests.core_fangraphs.requests.Session.get")
 def test_get_projections_data_valid_batting_positions(mock_get, core_fangraphs):
     """Test get_projections_data with various valid batting positions."""
     mock_response = Mock()
@@ -221,7 +222,7 @@ def test_get_projections_data_valid_batting_positions(mock_get, core_fangraphs):
         assert result == {"data": "test"}
 
 
-@patch("fangraphs_api_extractor.requests.core_fangraphs.requests.get")
+@patch("fangraphs_api_extractor.requests.core_fangraphs.requests.Session.get")
 def test_get_projections_data_valid_projection_systems(mock_get, core_fangraphs):
     """Test get_projections_data with various valid projection systems."""
     mock_response = Mock()
@@ -238,7 +239,78 @@ def test_get_projections_data_valid_projection_systems(mock_get, core_fangraphs)
         assert result == {"data": "test"}
 
 
-@patch("fangraphs_api_extractor.requests.core_fangraphs.requests.get")
+def _flaresolverr_solution():
+    """Build a fake FlareSolverr `request.get` response."""
+    resp = Mock()
+    resp.json.return_value = {
+        "status": "ok",
+        "solution": {
+            "userAgent": "Mozilla/5.0 (X11; Linux x86_64) Chrome/148.0.0.0",
+            "cookies": [
+                {"name": "cf_clearance", "value": "TOKEN", "domain": ".fangraphs.com"}
+            ],
+        },
+    }
+    return resp
+
+
+@patch("fangraphs_api_extractor.requests.core_fangraphs.requests.post")
+@patch("fangraphs_api_extractor.requests.core_fangraphs.requests.Session.get")
+def test_get_solves_cloudflare_when_configured(mock_get, mock_post, core_fangraphs):
+    """When FLARESOLVERR_URL is set, _get solves once and adopts the cf_clearance
+    cookie plus the solver's User-Agent on the session."""
+    core_fangraphs.flaresolverr_url = "http://flaresolverr:8191/v1"
+    core_fangraphs._clearance_ready = False
+    mock_post.return_value = _flaresolverr_solution()
+
+    ok = Mock()
+    ok.status_code = 200
+    ok.json.return_value = {"data": "test"}
+    mock_get.return_value = ok
+
+    result = core_fangraphs._get(params={"test": "param"})
+
+    assert result == {"data": "test"}
+    mock_post.assert_called_once()  # solved exactly once
+    assert core_fangraphs.session.headers["User-Agent"].endswith("Chrome/148.0.0.0")
+    assert core_fangraphs.session.cookies.get("cf_clearance") == "TOKEN"
+
+
+@patch("fangraphs_api_extractor.requests.core_fangraphs.requests.post")
+@patch("fangraphs_api_extractor.requests.core_fangraphs.requests.Session.get")
+def test_get_resolves_on_mid_run_403(mock_get, mock_post, core_fangraphs):
+    """A 403 mid-run triggers exactly one re-solve and retry."""
+    core_fangraphs.flaresolverr_url = "http://flaresolverr:8191/v1"
+    core_fangraphs._clearance_ready = True  # already have (now-stale) clearance
+    mock_post.return_value = _flaresolverr_solution()
+
+    forbidden = Mock()
+    forbidden.status_code = 403
+    ok = Mock()
+    ok.status_code = 200
+    ok.json.return_value = {"data": "test"}
+    mock_get.side_effect = [forbidden, ok]
+
+    result = core_fangraphs._get(params={"test": "param"})
+
+    assert result == {"data": "test"}
+    assert mock_get.call_count == 2  # initial 403 + retry
+    mock_post.assert_called_once()  # re-solved once
+
+
+@patch("fangraphs_api_extractor.requests.core_fangraphs.requests.Session.get")
+def test_get_raises_on_unresolved_non_200(mock_get, core_fangraphs):
+    """A non-200 (no solver configured) raises rather than crashing on r.json()."""
+    forbidden = Mock()
+    forbidden.status_code = 403
+    forbidden.json.side_effect = ValueError("not JSON")
+    mock_get.return_value = forbidden
+
+    with pytest.raises(RuntimeError, match="HTTP 403"):
+        core_fangraphs._get(params={"test": "param"})
+
+
+@patch("fangraphs_api_extractor.requests.core_fangraphs.requests.Session.get")
 def test_get_projections_data_valid_position_groups(mock_get, core_fangraphs):
     """Test get_projections_data with all valid position groups."""
     mock_response = Mock()

--- a/tests/requests/test_core_fangraphs.py
+++ b/tests/requests/test_core_fangraphs.py
@@ -298,6 +298,22 @@ def test_get_resolves_on_mid_run_403(mock_get, mock_post, core_fangraphs):
     mock_post.assert_called_once()  # re-solved once
 
 
+@patch("fangraphs_api_extractor.requests.core_fangraphs.requests.post")
+@patch("fangraphs_api_extractor.requests.core_fangraphs.requests.Session.get")
+def test_solve_raises_when_flaresolverr_fails(mock_get, mock_post, core_fangraphs):
+    """A non-ok FlareSolverr status surfaces as a RuntimeError."""
+    core_fangraphs.flaresolverr_url = "http://flaresolverr:8191/v1"
+    core_fangraphs._clearance_ready = False
+    failed = Mock()
+    failed.json.return_value = {"status": "error", "message": "challenge timeout"}
+    mock_post.return_value = failed
+
+    with pytest.raises(RuntimeError, match="challenge timeout"):
+        core_fangraphs._get(params={"test": "param"})
+
+    mock_get.assert_not_called()  # never reached the API
+
+
 @patch("fangraphs_api_extractor.requests.core_fangraphs.requests.Session.get")
 def test_get_raises_on_unresolved_non_200(mock_get, core_fangraphs):
     """A non-200 (no solver configured) raises rather than crashing on r.json()."""


### PR DESCRIPTION
## Problem

Fangraphs put `/api/projections` behind a **Cloudflare managed JS challenge** (`cf-mitigated: challenge` / "Just a moment"). In-season `projs_updated` and `ros` pulls started returning **403**; the pre-season `projections` slot only looked healthy because its data was scraped before the wall went up — a timeline artifact, not an endpoint-specific block.

## Why headers/impersonation can't fix it

A managed JS challenge checks whether you can *execute its JavaScript in a real browser*, not what you claim to be. All of these still 403 (evidence in `docs/the-wall-goes-up.md`):

| Approach | Result |
|---|---|
| `requests` + browser UA / Referer / Accept | 403 |
| `curl_cffi` `impersonate=chrome` (TLS/JA3) | 403 |
| `cloudscraper` | 403 |
| Playwright headless / headful, real Chrome channel | stuck on challenge |

A real human Chrome on the same IP loaded instantly → the wall is **automation detection**, not IP reputation.

## Fix

`CoreFangraphs` delegates solving to a **FlareSolverr sidecar** when `FLARESOLVERR_URL` is set: solves once lazily, adopts the `cf_clearance` cookie **+ the solver's User-Agent** on the session, and re-solves once on a mid-run 403. `cf_clearance` is bound to the solving browser's UA **and egress IP**, so the solver must be co-located with the extractor (same NAT egress — handled in the MTBL_Prefect compose PR).

Also fixes a **latent bug**: `_get()` called module-level `requests.get()` and bypassed `self.session`, so the session User-Agent (and any cf_clearance cookie) was never sent. Now uses `self.session.get()` — which is also what makes cookie reuse work.

## Verification

Real extractor via `uv run --directory` (mirrors Prefect):
```
Obtained Cloudflare clearance via FlareSolverr
Slot 'projections':   4186 hitters, 5367 pitchers
Slot 'projs_updated': 4377 hitters, 5588 pitchers   (was 403)
Slot 'ros':            630 hitters, 3361 pitchers    (was 403)
```

## Notes
- Companion PR: `MTBLL/MTBL_Prefect` adds the `flaresolverr` service + `FLARESOLVERR_URL`.
- `FLARESOLVERR_URL` unset → legacy behavior (pulls 403 while the challenge is active).
- Reviewed (thread-safety, 403 retry loop, cookie domain None-guard, non-200 JSON parse) — 3 issues found and fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)